### PR TITLE
adding in ability to pass context object to ajaxCallBack via the native ...

### DIFF
--- a/jquery.mobile.listomatic.js
+++ b/jquery.mobile.listomatic.js
@@ -4,6 +4,7 @@
  * Copyright (c) Stakbit.com
  * Released under the MIT license.
  * http://listomatic.stakbit.com
+ * **
  */
 (function($) {
 	var a, listOffset = 0, listOffsetSearch = 0, registeredAjax, registeredAjaxContext, searchTerm, cachedList;

--- a/jquery.mobile.listomatic.js
+++ b/jquery.mobile.listomatic.js
@@ -6,7 +6,7 @@
  * http://listomatic.stakbit.com
  */
 (function($) {
-	var a, listOffset = 0, listOffsetSearch = 0, registeredAjax, searchTerm, cachedList;
+	var a, listOffset = 0, listOffsetSearch = 0, registeredAjax, registeredAjaxContext, searchTerm, cachedList;
 	$.widget( "mobile.listomatic", $.mobile.widget, {
 		options: {
 			perPage: 10,
@@ -21,7 +21,7 @@
 				self._refreshAt(00, 00, 00); // refresh at midnight - refreshAt(15,35,0); Will refresh the page at 3:35pm
 			}
 			if ($(this.element).is('[data-listomatic]')) {
-				$.when(a = self._getAjaxCall()())
+				$.when(a = self._invokeAjaxCall())
 				.then(function(){ 
 					self._moreBtn(self.element);
 					cachedList = $('[data-listomatic]').html();	
@@ -33,7 +33,7 @@
 						} else {
 							self._setOffset();
 						}
-						$.when(a = self._getAjaxCall()())
+						$.when(a = self._invokeAjaxCall())
 						.then(function(){
 							self._moreBtn(self.element);
 							if (!self._hasSearchTerm()) {
@@ -53,7 +53,7 @@
 					if (self._hasSearchTerm()) {
 						self._resetOffsetSearch();
 						$datalistomatic.empty();
-						$.when(a = self._getAjaxCall()())
+						$.when(a = self._invokeAjaxCall())
 						.then(function(){
 							self._moreBtn($datalistomatic);
 						});
@@ -143,8 +143,17 @@
 		_resetOffsetSearch: function() {
 			listOffsetSearch = 0;
  		},
-		registerAjaxCall: function(f) {
+		registerAjaxCall: function(f, context) {
 			registeredAjax = f;
+			registeredAjaxContext = context;
+		},
+		_invokeAjaxCall: function() {
+			var ajaxCallback = _getAjaxCall();
+			if(registeredAjaxContext) {
+				ajaxCallback.call(registeredAjaxContext);
+			} else {
+				ajaxCallback.call();
+			}
 		},
 		_getAjaxCall: function() {
 			return registeredAjax;


### PR DESCRIPTION
To Whomever It May Concern,

I recently began working on a jquery-mobile based application and was looking for a cool plugin that allowed for pagination/lazy loading of jqm lists. I did a Google search and found your plugin. So far I'm a big fan! It really addresses the core problems I had!

However, the app I am working on also implements Backbone.js for code structure/organization. As I was integrating your library into my application, I wanted a way to be able to pass the context of my Backbone View into the callback function registered by the $.mobile.listomatic.prototype.registerAjaxCall() function. This is so that when the success callback was triggered, I could directly add the returned data into the Backbone Collection associated with my Backbone View that wraps my listview.

Therefore I made some slight modifications to your code that allow the user to pass an additional context object into the registerAjaxCall() function. When the callback is invoked by the listomatic code, it first checks to see if a context object is set. If so, it calls the callback using the native .call() method, passing in the registered context object. If no context object is set, it just calls it without the context object.

Let me know what you think! I believe this would be a really useful addition to this library.

Thanks!
-Rohit K 
