### PR TITLE
Manual refresh

### DIFF
--- a/jquery.mobile.listomatic.js
+++ b/jquery.mobile.listomatic.js
@@ -22,11 +22,7 @@
 				self._refreshAt(00, 00, 00); // refresh at midnight - refreshAt(15,35,0); Will refresh the page at 3:35pm
 			}
 			if ($(this.element).is('[data-listomatic]')) {
-				$.when(a = self._invokeAjaxCall())
-				.then(function(){ 
-					self._moreBtn(self.element);
-					cachedList = $('[data-listomatic]').html();	
-				});
+				self.refreshList();
 				this.element.click(function(e){
 					if ($(e.target).closest('li.listomatic').length > 0) {
 						if (self._hasSearchTerm()) {
@@ -34,13 +30,7 @@
 						} else {
 							self._setOffset();
 						}
-						$.when(a = self._invokeAjaxCall())
-						.then(function(){
-							self._moreBtn(self.element);
-							if (!self._hasSearchTerm()) {
-								cachedList = $('[data-listomatic]').html();
-							}
-						});
+						self.refreshList();
 					} 
 				});	
 			} else if ($(this.element).is('[data-type=search]')) {
@@ -54,15 +44,28 @@
 					if (self._hasSearchTerm()) {
 						self._resetOffsetSearch();
 						$datalistomatic.empty();
-						$.when(a = self._invokeAjaxCall())
-						.then(function(){
-							self._moreBtn($datalistomatic);
-						});
+						self.refreshList($datalistomatic.get(0));
 					} else {
 						self._resetSearchView($datalistomatic);
 					}
 				});
 			}
+		},
+		refreshList: function(listDOMRef) {
+			var self = this;
+			if(!listDOMRef) listDOMRef = this.element;
+			if(self._isValidList(listDOMRef)) {
+				$.when(a = self._invokeAjaxCall())
+				.then(function(){
+					_moreBtn(listDOMRef);
+					if (!self._hasSearchTerm()) {
+						cachedList = $(listDOMRef).html();
+					}
+				});
+			}
+		},
+		_isValidList: function(e) {
+			return $(e).is('[data-listomatic]')
 		},
 		_moreBtn: function(e) {
 			var aResp = $.parseJSON(a.responseText);

--- a/jquery.mobile.listomatic.js
+++ b/jquery.mobile.listomatic.js
@@ -1,10 +1,9 @@
 /*
- * jQuery Mobile Listomatic Plugin v0.5.3
+ * jQuery Mobile Listomatic Plugin v0.5.3 RC1
  * Plugin to provide jquery mobile listview pagination
  * Copyright (c) Stakbit.com
  * Released under the MIT license.
  * http://listomatic.stakbit.com
- * **
  */
 (function($) {
 	var a, listOffset = 0, listOffsetSearch = 0, registeredAjax, registeredAjaxContext, searchTerm, cachedList;
@@ -64,8 +63,8 @@
 				});
 			}
 		},
-		_isValidList: function(e) {
-			return $(e).is('[data-listomatic]');
+		_isValidList: function(listDOMRef) {
+			return $(listDOMRef).is('[data-listomatic]');
 		},
 		_moreBtn: function(e) {
 			var aResp = $.parseJSON(a.responseText);
@@ -154,9 +153,9 @@
 		_invokeAjaxCall: function() {
 			var ajaxCallback = this._getAjaxCall();
 			if(registeredAjaxContext) {
-				ajaxCallback.call(registeredAjaxContext);
+				return ajaxCallback.call(registeredAjaxContext);
 			} else {
-				ajaxCallback.call();
+				return ajaxCallback.call();
 			}
 		},
 		_getAjaxCall: function() {
@@ -176,7 +175,7 @@
 			}
 		}
 	});
-	$(document).on( "pageinit", function(e){
+	$(document).on( "pageinit", function(e) {
 		$.mobile.listomatic.prototype.enhanceWithin(e.target, true);
 	});
 })(jQuery);

--- a/jquery.mobile.listomatic.js
+++ b/jquery.mobile.listomatic.js
@@ -21,7 +21,7 @@
 			if (this.options.refreshContent) {
 				self._refreshAt(00, 00, 00); // refresh at midnight - refreshAt(15,35,0); Will refresh the page at 3:35pm
 			}
-			if ($(this.element).is('[data-listomatic]')) {
+			if (this._isValidList(this.element)) {
 				self.refreshList();
 				this.element.click(function(e){
 					if ($(e.target).closest('li.listomatic').length > 0) {
@@ -54,10 +54,10 @@
 		refreshList: function(listDOMRef) {
 			var self = this;
 			if(!listDOMRef) listDOMRef = this.element;
-			if(self._isValidList(listDOMRef)) {
-				$.when(a = self._invokeAjaxCall())
-				.then(function(){
-					_moreBtn(listDOMRef);
+			if(this._isValidList(listDOMRef)) {
+				$.when(a = this._invokeAjaxCall())
+				.then(function() {
+					self._moreBtn(listDOMRef);
 					if (!self._hasSearchTerm()) {
 						cachedList = $(listDOMRef).html();
 					}
@@ -65,7 +65,7 @@
 			}
 		},
 		_isValidList: function(e) {
-			return $(e).is('[data-listomatic]')
+			return $(e).is('[data-listomatic]');
 		},
 		_moreBtn: function(e) {
 			var aResp = $.parseJSON(a.responseText);
@@ -152,7 +152,7 @@
 			registeredAjaxContext = context;
 		},
 		_invokeAjaxCall: function() {
-			var ajaxCallback = _getAjaxCall();
+			var ajaxCallback = this._getAjaxCall();
 			if(registeredAjaxContext) {
 				ajaxCallback.call(registeredAjaxContext);
 			} else {


### PR DESCRIPTION
Hi Jose,

I am continuing to integrate your plugin into my application. As I was going through the integration process, I found the need to be able to manually trigger a refresh of the list. A 'refresh' consists of:

-A call to _invokeAjaxCall()
-When that is completed, a call to _moreBtn() to decided whether or not to show the "Show More" btn.
-Caching the list results in the scoped variable cachedList

When I was examining the codebase, I saw that the above sequence was repeated 3 times within the _create() function, so I thought it might be best to just refactor it into its own method.

I decided to make it a public method because in my application, I am using the plugin in a pop-over panel view. Whenever the popover is opened, I wanted to be able to update the URL that I am making my GET request to in the AJAX callback, and then trigger a list refresh.

I was also pondering caching the DOM reference to the list element (instead of passing it in as an argument to the listDOMRef parameter). Might be a little cleaner.

Check out the updates and let me know what you think! I just added them on to the latest version of the storeAjaxCallbackContext branch code in your repository.

Thanks!
-Rohit K
